### PR TITLE
Firewall 5 project: rename to markdown file

### DIFF
--- a/_projects/firewall-5_performant_WiFi_packet_handling_with_eBPF.md
+++ b/_projects/firewall-5_performant_WiFi_packet_handling_with_eBPF.md
@@ -12,7 +12,7 @@ initiatives:
   - GSoC 2024
 issues: []
 size: 350 hours
-markdown: firewall5.md
+markdown: firewall-5_performant_WiFi_packet_handling_with_eBPF.md
 mentors:
   - name: thuehn
     contact:


### PR DESCRIPTION
Change the Firewall 5 project file into a markdown file and adjust the `markdown` option accordingly.